### PR TITLE
feat(todos-api) : add Dockerfile and run script for todos-api

### DIFF
--- a/todos-api/Dockerfile
+++ b/todos-api/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+
+WORKDIR /home/app/todo_app
+
+COPY . .
+
+RUN chmod +x ./run.sh
+
+CMD ["./run.sh"]

--- a/todos-api/package.json
+++ b/todos-api/package.json
@@ -4,7 +4,8 @@
   "description": "API for Todos in my little example app",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "start": "node server.js"
   },
   "author": "elgris <iddqd07@yandex.ru>",
   "license": "MIT",

--- a/todos-api/run.sh
+++ b/todos-api/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eux
+
+# Ensure npm exists or is installed (for Alpine Linux)
+if ! command -v npm >/dev/null 2>&1; then
+   echo "npm not found. Installing nodejs and npm..."
+   apk update && apk add --no-cache nodejs npm
+fi
+
+echo "Installing dependencies..."
+if ! npm install; then
+   echo "Something went wrong while trying to install dependencies for the Node.js application"
+   exit 1
+fi
+
+echo "Starting application..."
+if ! npm run start; then
+   echo "Something went wrong while trying to start the application"
+   exit 1
+fi


### PR DESCRIPTION
This pull request introduces Docker support for the `todos-api` application and improves the development workflow by adding a startup script and refining npm scripts. The main changes focus on containerization, automated dependency installation, and clearer separation between development and production environments.

**Dockerization and Startup Automation:**

* Added a new `Dockerfile` to containerize the `todos-api` app, specifying the use of the `node:22-alpine` image, setting up the working directory, copying the app files, ensuring the startup script is executable, and setting the container's default command to run the script (`run.sh`).
* Introduced a `run.sh` script that ensures `npm` is available, installs dependencies, and starts the application, with error handling for each step.

**Development Workflow Improvements:**

* Updated `package.json` to separate development and production start commands: `dev` uses `nodemon` for live reloading in development, and `start` uses `node` for production.